### PR TITLE
fixing index of 3rd component of normals

### DIFF
--- a/src/DracoPy.h
+++ b/src/DracoPy.h
@@ -185,7 +185,7 @@ namespace DracoFunctions {
       }
       meshObject.normals.push_back(normal_val[0]);
       meshObject.normals.push_back(normal_val[1]);
-      meshObject.normals.push_back(normal_val[3]);
+      meshObject.normals.push_back(normal_val[2]);
     }
 
     meshObject.decode_status = successful;


### PR DESCRIPTION
The 3rd index of normals was wrong, as a consequences all Z components of normals in decoded meshes were wrong.