### PR TITLE
Support for more general geometry attributes

### DIFF
--- a/src/DracoPy.h
+++ b/src/DracoPy.h
@@ -141,68 +141,63 @@ namespace DracoFunctions {
       switch (att->data_type()) {
         case draco::DT_FLOAT32: {
           attr.float_data.reserve(num_values);
-          float *values = new float[att->num_components()];
+          std::unique_ptr<float[]> values(new float[att->num_components()]);
           for (draco::PointIndex v(0); v < mesh->num_points(); ++v) {
-            if (att->ConvertValue<float>(att->mapped_index(v), att->num_components(), values)) {
+            if (att->ConvertValue<float>(att->mapped_index(v), att->num_components(), values.get())) {
               for (int c = 0; c < att->num_components(); ++c) {
                 attr.float_data.push_back(values[c]);
               }
             }
           }
-          delete[] values;
           break;
         }
         case draco::DT_UINT8: {
           attr.byte_data.reserve(num_values);
-          uint8_t *values = new uint8_t[att->num_components()];
+          std::unique_ptr<uint8_t[]> values(new uint8_t[att->num_components()]);
           for (draco::PointIndex v(0); v < mesh->num_points(); ++v) {
-            if (att->ConvertValue<uint8_t>(att->mapped_index(v), att->num_components(), values)) {
+            if (att->ConvertValue<uint8_t>(att->mapped_index(v), att->num_components(), values.get())) {
               for (int c = 0; c < att->num_components(); ++c) {
                 attr.byte_data.push_back(values[c]);
               }
             }
           }
-          delete[] values;
           break;
         }
         case draco::DT_UINT16: {
           attr.uint_data.reserve(num_values);
-          uint16_t *values = new uint16_t[att->num_components()];
+          std::unique_ptr<uint16_t[]> values(new uint16_t[att->num_components()]);
           for (draco::PointIndex v(0); v < mesh->num_points(); ++v) {
-            if (att->ConvertValue<uint16_t>(att->mapped_index(v), att->num_components(), values)) {
+            if (att->ConvertValue<uint16_t>(att->mapped_index(v), att->num_components(), values.get())) {
               for (int c = 0; c < att->num_components(); ++c) {
                 attr.uint_data.push_back(static_cast<uint32_t>(values[c]));
               }
             }
           }
-          delete[] values;
           break;
         }
         case draco::DT_UINT32: {
           attr.uint_data.reserve(num_values);
-          uint32_t *values = new uint32_t[att->num_components()];
+          std::unique_ptr<uint32_t[]> values(new uint32_t[att->num_components()]);
           for (draco::PointIndex v(0); v < mesh->num_points(); ++v) {
-            if (att->ConvertValue<uint32_t>(att->mapped_index(v), att->num_components(), values)) {
+            if (att->ConvertValue<uint32_t>(att->mapped_index(v), att->num_components(), values.get())) {
               for (int c = 0; c < att->num_components(); ++c) {
                 attr.uint_data.push_back(values[c]);
               }
             }
           }
-          delete[] values;
           break;
         }
         default: {
           // For other data types, try to convert to float as fallback
           attr.float_data.reserve(num_values);
-          float *values = new float[att->num_components()];
+          std::unique_ptr<float[]> values(new float[att->num_components()]);
           for (draco::PointIndex v(0); v < mesh->num_points(); ++v) {
-            if (att->ConvertValue<float>(att->mapped_index(v), att->num_components(), values)) {
+            if (att->ConvertValue<float>(att->mapped_index(v), att->num_components(), values.get())) {
               for (int c = 0; c < att->num_components(); ++c) {
                 attr.float_data.push_back(values[c]);
               }
             }
           }
-          delete[] values;
           break;
         }
       }

--- a/src/DracoPy.h
+++ b/src/DracoPy.h
@@ -350,8 +350,6 @@ namespace DracoFunctions {
     std::vector<int> generic_attr_ids;
     generic_attr_ids.reserve(unique_ids.size());
 
-    //std::cout << "DEBUG: attr_names size: " << unique_ids.size() << std::endl;
-
     for (size_t i = 0; i < unique_ids.size(); ++i) {
       draco::GeometryAttribute generic_attr;
       draco::DataType dtype = static_cast<draco::DataType>(attr_data_types[i]);
@@ -374,8 +372,6 @@ namespace DracoFunctions {
       generic_attr_ids.push_back(generic_att_id);
     }
 
-
-    // std::cout << "DEBUG: Encode all generic attributes, total: " << attr_ids.size() << std::endl;
 
     const int pos_att_id = mesh.AddAttribute(positions_attr, true, num_pts);
     std::vector<int32_t> pts_int32;

--- a/src/DracoPy.pxd
+++ b/src/DracoPy.pxd
@@ -1,6 +1,5 @@
 #cython: language_level=3
 from libcpp.vector cimport vector
-from libcpp.string cimport string
 from libc.stdint cimport uint8_t, uint16_t, uint32_t
 from libcpp cimport bool
 

--- a/src/DracoPy.pxd
+++ b/src/DracoPy.pxd
@@ -1,6 +1,6 @@
 #cython: language_level=3
 from libcpp.vector cimport vector
-from libc.stdint cimport uint8_t, uint32_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t
 from libcpp cimport bool
 
 cimport numpy as cnp
@@ -17,37 +17,39 @@ cdef extern from "DracoPy.h" namespace "DracoFunctions":
     cdef enum encoding_status:
         successful_encoding, failed_during_encoding
 
-    cdef struct PointCloudObject:
-        vector[float] points
+    cdef struct AttributeData:
+        int unique_id
+        int num_components
+        int data_type
+        int attribute_type
+        vector[float] float_data
+        vector[uint32_t] uint_data
+        vector[uint8_t] byte_data
 
+    cdef struct PointCloudObject:
+        vector[AttributeData] attributes
         # Encoding options
         bool encoding_options_set
-        bool colors_set
         int quantization_bits
         double quantization_range
         vector[double] quantization_origin
 
         # Represents the decoding success or error message
         decoding_status decode_status
-        vector[uint8_t] colors
 
     cdef struct MeshObject:
-        vector[float] points
-        vector[unsigned int] faces
-
-        vector[float] normals
-        vector[float] tex_coord
-
+        vector[AttributeData] attributes
         # Encoding options
         bool encoding_options_set
-        bool colors_set
         int quantization_bits
         double quantization_range
         vector[double] quantization_origin
 
         # Represents the decoding success or error message
         decoding_status decode_status
-        vector[uint8_t] colors
+        
+        # Mesh-specific
+        vector[unsigned int] faces
 
     cdef struct EncodedObject:
         vector[unsigned char] buffer
@@ -70,7 +72,13 @@ cdef extern from "DracoPy.h" namespace "DracoFunctions":
         const vector[float] tex_coord,
         const uint8_t tex_coord_channel,
         const vector[float] normals,
-        const uint8_t has_normals
+        const uint8_t has_normals,
+        const vector[float] tangents,
+        const uint8_t tangent_channel,
+        const vector[unsigned short] joints,
+        const uint8_t joint_channel,
+        const vector[float] weights,
+        const uint8_t weight_channel
     ) except +
 
     EncodedObject encode_point_cloud(

--- a/src/DracoPy.pxd
+++ b/src/DracoPy.pxd
@@ -1,5 +1,6 @@
 #cython: language_level=3
 from libcpp.vector cimport vector
+from libcpp.string cimport string
 from libc.stdint cimport uint8_t, uint16_t, uint32_t
 from libcpp cimport bool
 
@@ -73,12 +74,13 @@ cdef extern from "DracoPy.h" namespace "DracoFunctions":
         const uint8_t tex_coord_channel,
         const vector[float] normals,
         const uint8_t has_normals,
-        const vector[float] tangents,
-        const uint8_t tangent_channel,
-        const vector[unsigned short] joints,
-        const uint8_t joint_channel,
-        const vector[float] weights,
-        const uint8_t weight_channel
+        vector[uint8_t]& unique_ids,
+        vector[vector[float]]& attr_float_data,
+        vector[vector[uint8_t]]& attr_uint8_data,
+        vector[vector[uint16_t]]& attr_uint16_data,
+        vector[vector[uint32_t]]& attr_uint32_data,
+        vector[int]& attr_data_types,
+        vector[int]& attr_num_components
     ) except +
 
     EncodedObject encode_point_cloud(

--- a/src/DracoPy.pyx
+++ b/src/DracoPy.pyx
@@ -286,7 +286,7 @@ def encode(
         assert len(joints.shape) == 2, "Joints must be 2D"
         joint_channel = joints.shape[1]
         assert 1 <= joint_channel <= 16, "Number of joint channels must be in range [1, 16]"
-        joints = joints.astype(np.uint16)
+        joints = joints.astype(np.uint16, copy=False)
         jointsview = joints.reshape((joints.size,))
 
     weight_channel = 0

--- a/src/DracoPy.pyx
+++ b/src/DracoPy.pyx
@@ -225,11 +225,23 @@ def encode(
         vertices. Use None if mesh does not have texture coordinates.
     Normals is a numpy array of normal vectors (float) with shape (N, 3). N is the number of
         vertices. Use None if mesh does not have normal vectors.
-    Generic_attributes is a dictionary of additional attributes to encode.
-        The keys are attribute unique_ids and the values are numpy arrays with shape (N, K).
-        N is the number of vertices. K is the number of components for that attribute.
-        Supported data types are float, uint8, uint16, and uint32.
-        Use None if there are no generic attributes to encode.
+    Generic_attributes is a dictionary of additional attributes to encode, where:
+       - Keys: unique_ids (integer identifiers for each attribute, e.g., 0, 1, 2...)
+       - Values: numpy arrays with shape (N, K) where:
+         - N = number of vertices in the mesh
+         - K = number of components per attribute
+       - Supported data types: float, uint8, uint16, uint32
+       - Use None if there are no generic attributes to encode.
+
+        @example
+        ```python
+        # Example with additional vertex tangents, joints, and weights
+        generic_attributes = {
+            0: vertex_tangents,    # shape (1000, 3) for tangents, unique_id is 0
+            1: vertex_joints,      # shape (1000, 4) for joints, unique_id is 1
+            4: vertex_weights      # shape (1000, 4) for weights, unique_id is 4
+        }
+        ```
     """
     assert 0 <= compression_level <= 10, "Compression level must be in range [0, 10]"
 

--- a/tests.py
+++ b/tests.py
@@ -275,26 +275,31 @@ def test_generic_attributes():
     test_weights = np.array([[0.5, 0.5]] * mesh.points.shape[0], dtype=np.float32)
 
     # Encode with test attributes
-    binary = DracoPy.encode(mesh.points, mesh.faces, tangents=test_tangents, joints=test_joints, weights=test_weights)
+    generic_attributes = {
+        0: test_tangents,
+        1: test_joints,
+        6: test_weights
+    }
+    binary = DracoPy.encode(mesh.points, mesh.faces, generic_attributes=generic_attributes)
 
     # Decode and verify attributes
     decoded_mesh = DracoPy.decode(binary)
 
-    decoded_tangents = decoded_mesh.get_attribute_by_unique_id(0) # first generic attribute
-    decoded_joints = decoded_mesh.get_attribute_by_unique_id(1) # second generic attribute
-    decoded_weights = decoded_mesh.get_attribute_by_unique_id(2) # third generic attribute
+    decoded_tangents = decoded_mesh.get_attribute_by_unique_id(0)
+    decoded_joints = decoded_mesh.get_attribute_by_unique_id(1)
+    decoded_weights = decoded_mesh.get_attribute_by_unique_id(6)
 
-    assert decoded_tangents["attribute_type"] == 4 # GENERIC
-    assert decoded_tangents["data_type"] == 9 # FLOAT32
+    assert decoded_tangents["attribute_type"] == DracoPy.AttributeType.GENERIC
+    assert decoded_tangents["data_type"] == DracoPy.DataType.DT_FLOAT32
     assert decoded_tangents["num_components"] == 3
     assert np.allclose(decoded_tangents["data"], test_tangents)
 
-    assert decoded_joints["attribute_type"] == 4 # GENERIC
-    assert decoded_joints["data_type"] == 4 # UINT32
+    assert decoded_joints["attribute_type"] == DracoPy.AttributeType.GENERIC
+    assert decoded_joints["data_type"] == DracoPy.DataType.DT_UINT32
     assert decoded_joints["num_components"] == 2
     assert np.array_equal(decoded_joints["data"], test_joints)
 
-    assert decoded_weights["attribute_type"] == 4 # GENERIC
-    assert decoded_weights["data_type"] == 9 # FLOAT32
+    assert decoded_weights["attribute_type"] == DracoPy.AttributeType.GENERIC
+    assert decoded_weights["data_type"] == DracoPy.DataType.DT_FLOAT32
     assert decoded_weights["num_components"] == 2
     assert np.allclose(decoded_weights["data"], test_weights)


### PR DESCRIPTION
This pull request adds support for decoding generic geometry attributes (such as `tangents`, `joints`, `weights`, etc) to meet the requirements of specifications such as glTF.
The API remains backward compatible.

In addition, this PR also fixes the `normals` decoding issue mentioned in Issue #54.