### PR TITLE
Add support for reading and writing named generic attributes

### DIFF
--- a/src/DracoPy.pxd
+++ b/src/DracoPy.pxd
@@ -1,7 +1,8 @@
 #cython: language_level=3
 from libcpp.vector cimport vector
-from libc.stdint cimport uint8_t, uint16_t, uint32_t
+from libc.stdint cimport int8_t, uint8_t, uint16_t, uint32_t
 from libcpp cimport bool
+from libcpp.string cimport string
 
 cimport numpy as cnp
 import numpy as np
@@ -22,6 +23,7 @@ cdef extern from "DracoPy.h" namespace "DracoFunctions":
         int num_components
         int data_type
         int attribute_type
+        string name
         vector[float] float_data
         vector[uint32_t] uint_data
         vector[uint8_t] byte_data
@@ -73,13 +75,14 @@ cdef extern from "DracoPy.h" namespace "DracoFunctions":
         const uint8_t tex_coord_channel,
         const vector[float] normals,
         const uint8_t has_normals,
-        vector[uint8_t]& unique_ids,
+        vector[int8_t]& unique_ids,
         vector[vector[float]]& attr_float_data,
         vector[vector[uint8_t]]& attr_uint8_data,
         vector[vector[uint16_t]]& attr_uint16_data,
         vector[vector[uint32_t]]& attr_uint32_data,
         vector[int]& attr_data_types,
-        vector[int]& attr_num_components
+        vector[int]& attr_num_components,
+        vector[string]& attr_names
     ) except +
 
     EncodedObject encode_point_cloud(


### PR DESCRIPTION
Building on https://github.com/seung-lab/DracoPy/pull/59, adds support for named generic attributes.

Besides using `unique_id` to identify attributes, it's also possible to use names stored in attribute metadata entries.

This pattern is supported the official JavaScript bindings, see [Decoder::GetAttributeIdByName](https://github.com/google/draco/blob/1433f77b507468d4fa5c4ecd4f889407225c4e92/src/draco/javascript/emscripten/decoder_webidl_wrapper.cc#L139).

I extended the work from #59 to allow string keys in the `generic_attributes` dictionary passed to `encode()`. When the key for an attribute is a string rather than an integer, an attribute metadata entry is added to associate the name with the attribute's ID.

When reading generic attributes, names are extracted if present and included in the AttributeData struct. DracoMesh has a new `get_attribute_by_name()`  method to retrieve named generic attributes by their name.

New unit tests cover this functionality and verify that appropriate exceptions are raised when `generic_attributes` dictionary keys are of an invalid type.