### PR TITLE
Enable generic attributes for point cloud encode/decode

### DIFF
--- a/src/DracoPy.h
+++ b/src/DracoPy.h
@@ -291,6 +291,13 @@ namespace DracoFunctions {
     //    manually.
     draco::Mesh mesh; //Initialize a draco mesh
 
+    // Ensure unique ids for native attributes don't conflict with generic attributes
+    uint32_t next_unique_id = 0;
+    auto max_unique_id = std::max_element(unique_ids.begin(), unique_ids.end());
+    if (max_unique_id != unique_ids.end()) {
+      next_unique_id = *max_unique_id + 1;
+    }
+
     // Process vertices
     const size_t num_pts = points.size() / 3;
     mesh.set_num_points(num_pts);
@@ -331,6 +338,8 @@ namespace DracoFunctions {
                        sizeof(uint8_t) * colors_channel,   // byte stride
                        0);                                 // byte offset
       color_att_id = mesh.AddAttribute(colors_attr, true, num_pts);
+      mesh.attribute(color_att_id)->set_unique_id(next_unique_id);
+      next_unique_id++;
     }
     int tex_coord_att_id = -1;
     if(tex_coord_channel) {
@@ -343,6 +352,8 @@ namespace DracoFunctions {
                           sizeof(float) * tex_coord_channel,   // byte stride
                           0);                                  // byte offset
       tex_coord_att_id = mesh.AddAttribute(tex_coord_attr, true, num_pts);
+      mesh.attribute(tex_coord_att_id)->set_unique_id(next_unique_id);
+      next_unique_id++;
     }
 
     int normal_att_id = -1;
@@ -356,6 +367,8 @@ namespace DracoFunctions {
                        sizeof(float) * 3,                   // byte stride
                        0);                                  // byte offset
       normal_att_id = mesh.AddAttribute(normal_attr, true, num_pts);
+      mesh.attribute(normal_att_id)->set_unique_id(next_unique_id);
+      next_unique_id++;
     }
 
 
@@ -384,6 +397,9 @@ namespace DracoFunctions {
       }
       if (unique_ids[i] >= 0) {
         mesh.attribute(att_id)->set_unique_id(unique_ids[i]);
+      } else {
+        mesh.attribute(att_id)->set_unique_id(next_unique_id);
+        next_unique_id++;
       }
       if (!attr_names[i].empty()) {
         auto attribute_metadata = std::unique_ptr<draco::AttributeMetadata>(new draco::AttributeMetadata());
@@ -396,6 +412,8 @@ namespace DracoFunctions {
 
 
     const int pos_att_id = mesh.AddAttribute(positions_attr, true, num_pts);
+    mesh.attribute(pos_att_id)->set_unique_id(next_unique_id);
+    next_unique_id++;
     std::vector<int32_t> pts_int32;
     std::vector<uint32_t> pts_uint32;
     if (integer_mark == 1) {

--- a/src/DracoPy.h
+++ b/src/DracoPy.h
@@ -5,6 +5,7 @@
 #include<cmath>
 #include<vector>
 #include<cstddef>
+#include<sstream>
 #include "draco/compression/decode.h"
 #include "draco/compression/encode.h"
 #include "draco/compression/config/compression_shared.h"
@@ -386,18 +387,16 @@ namespace DracoFunctions {
       draco::DataType dtype = static_cast<draco::DataType>(attr_data_types[i]);
       int num_components = attr_num_components[i];
       if (dtype != draco::DT_FLOAT32 && dtype != draco::DT_UINT8 && dtype != draco::DT_UINT16 && dtype != draco::DT_UINT32) {
-        // Unsupported data type, skip
-        // std::cout << "DEBUG: Unsupported attribute data type for " << unique_ids[i] << std::endl;
-        generic_attr_ids.push_back(-1);
-        continue;
+        std::ostringstream oss;
+        oss << "Unsupported attribute data type for attribute with unique id " << int(unique_ids[i]);
+        throw std::invalid_argument(oss.str());
       }
       generic_attr.Init(draco::GeometryAttribute::GENERIC, nullptr, num_components, dtype, false, 0, 0);
       int att_id = mesh.AddAttribute(generic_attr, true, num_pts);
       if (att_id == -1) {
-        // Failed to add attribute, skip
-        // std::cout << "DEBUG: Failed to add attribute " << unique_ids[i] << std::endl;
-        generic_attr_ids.push_back(-1);
-        continue;
+        std::ostringstream oss;
+        oss << "Failed to add attribute with unique id " << int(unique_ids[i]);
+        throw std::runtime_error(oss.str());
       }
       if (unique_ids[i] >= 0) {
         mesh.attribute(att_id)->set_unique_id(unique_ids[i]);
@@ -461,8 +460,7 @@ namespace DracoFunctions {
         const auto &uint32_data = attr_uint32_data[j];
 
         if (generic_attr_ids[j] == -1) {
-          // Skip if attribute was not added
-          continue;
+          throw std::runtime_error("Should never be reached; all successfully added attributes should have nonnegative att_id.");
         } 
 
         if (attr_data_types[j] == draco::DT_FLOAT32) {
@@ -582,13 +580,15 @@ namespace DracoFunctions {
       draco::DataType dtype = static_cast<draco::DataType>(attr_data_types[j]);
       int num_components = attr_num_components[j];
       if (dtype != draco::DT_FLOAT32 && dtype != draco::DT_UINT8 && dtype != draco::DT_UINT16 && dtype != draco::DT_UINT32) {
-        // Unsupported data type, skip
-        continue;
+        std::ostringstream oss;
+        oss << "Unsupported attribute data type for attribute with unique id " << int(unique_ids[j]);
+        throw std::invalid_argument(oss.str());
       }
       int att_id = pcb.AddAttribute(draco::GeometryAttribute::GENERIC, num_components, dtype);
       if (att_id == -1) {
-        // Failed to add attribute, skip
-        continue;
+        std::ostringstream oss;
+        oss << "Failed to add attribute with unique id " << int(unique_ids[j]);
+        throw std::runtime_error(oss.str());
       }
       if (unique_ids[j] >= 0) {
         pcb.SetAttributeUniqueId(att_id, unique_ids[j]);

--- a/src/DracoPy.h
+++ b/src/DracoPy.h
@@ -293,6 +293,10 @@ namespace DracoFunctions {
 
     // Ensure unique ids for native attributes don't conflict with generic attributes
     uint32_t next_unique_id = 0;
+    auto min_unique_id = std::min_element(unique_ids.begin(), unique_ids.end());
+    if (min_unique_id != unique_ids.end() && *min_unique_id < -1) {
+      throw std::invalid_argument("Should never be reached; all unique_ids should be >= -1.");
+    }
     auto max_unique_id = std::max_element(unique_ids.begin(), unique_ids.end());
     if (max_unique_id != unique_ids.end()) {
       next_unique_id = *max_unique_id + 1;
@@ -534,6 +538,10 @@ namespace DracoFunctions {
 
     // Ensure unique ids for native attributes don't conflict with generic attributes
     uint32_t next_unique_id = 0;
+    auto min_unique_id = std::min_element(unique_ids.begin(), unique_ids.end());
+    if (min_unique_id != unique_ids.end() && *min_unique_id < -1) {
+      throw std::invalid_argument("Should never be reached; all unique_ids should be >= -1.");
+    }
     auto max_unique_id = std::max_element(unique_ids.begin(), unique_ids.end());
     if (max_unique_id != unique_ids.end()) {
       next_unique_id = *max_unique_id + 1;

--- a/src/DracoPy.pxd
+++ b/src/DracoPy.pxd
@@ -95,5 +95,13 @@ cdef extern from "DracoPy.h" namespace "DracoFunctions":
         const bool create_metadata,
         const int integer_mark,
         const vector[uint8_t] colors,
-        const uint8_t colors_channel
+        const uint8_t colors_channel,
+        vector[int8_t]& unique_ids,
+        vector[vector[float]]& attr_float_data,
+        vector[vector[uint8_t]]& attr_uint8_data,
+        vector[vector[uint16_t]]& attr_uint16_data,
+        vector[vector[uint32_t]]& attr_uint32_data,
+        vector[int]& attr_data_types,
+        vector[int]& attr_num_components,
+        vector[string]& attr_names
     ) except +

--- a/src/DracoPy.pyx
+++ b/src/DracoPy.pyx
@@ -405,7 +405,11 @@ def encode(
             pointsview, quantization_bits, compression_level,
             quantization_range, <float*>&quant_origin[0],
             preserve_order, create_metadata, integer_mark,
-            colorsview, colors_channel
+            colorsview, colors_channel,
+            unique_ids, attr_float_data, attr_uint8_data,
+            attr_uint16_data, attr_uint32_data,
+            attr_data_types, attr_num_components,
+            attr_names
         )
     else:
         facesview = faces.reshape((faces.size,))

--- a/tests.py
+++ b/tests.py
@@ -282,16 +282,19 @@ def test_generic_attributes():
     generic_attributes = {
         0: test_tangents,
         1: test_joints,
-        6: test_weights
+        3: test_weights
     }
     binary = DracoPy.encode(mesh.points, mesh.faces, generic_attributes=generic_attributes)
 
     # Decode and verify attributes
     decoded_mesh = DracoPy.decode(binary)
 
+    assert len(decoded_mesh.attributes) == len(
+        set([attr["unique_id"] for attr in decoded_mesh.attributes])
+    )
     decoded_tangents = decoded_mesh.get_attribute_by_unique_id(0)
     decoded_joints = decoded_mesh.get_attribute_by_unique_id(1)
-    decoded_weights = decoded_mesh.get_attribute_by_unique_id(6)
+    decoded_weights = decoded_mesh.get_attribute_by_unique_id(3)
 
     assert decoded_tangents["attribute_type"] == DracoPy.AttributeType.GENERIC
     assert decoded_tangents["data_type"] == DracoPy.DataType.DT_FLOAT32
@@ -330,6 +333,9 @@ def test_named_generic_attributes():
     # Decode and verify attributes
     decoded_mesh = DracoPy.decode(binary)
 
+    assert len(decoded_mesh.attributes) == len(
+        set([attr["unique_id"] for attr in decoded_mesh.attributes])
+    )
     decoded_tangents = decoded_mesh.get_attribute_by_name('tangents')
     decoded_joints = decoded_mesh.get_attribute_by_name('joints')
     decoded_weights = decoded_mesh.get_attribute_by_name('weights')

--- a/tests.py
+++ b/tests.py
@@ -268,7 +268,8 @@ def test_normals_encoding():
     assert np.allclose(decoded_mesh.normals, test_normals)
 
 
-def test_generic_attributes():
+@pytest.mark.parametrize("object_type", [DracoPy.DracoMesh, DracoPy.DracoPointCloud])
+def test_generic_attributes(object_type):
     # Read reference mesh
     with open(os.path.join(testdata_directory, "bunny.drc"), 'rb') as draco_file:
         mesh = DracoPy.decode(draco_file.read())
@@ -284,17 +285,24 @@ def test_generic_attributes():
         1: test_joints,
         3: test_weights
     }
-    binary = DracoPy.encode(mesh.points, mesh.faces, generic_attributes=generic_attributes)
+    if object_type is DracoPy.DracoMesh:
+        binary = DracoPy.encode(mesh.points, mesh.faces, generic_attributes=generic_attributes)
+    else:
+        binary = DracoPy.encode(mesh.points, generic_attributes=generic_attributes)
 
     # Decode and verify attributes
-    decoded_mesh = DracoPy.decode(binary)
+    decoded_object = DracoPy.decode(binary)
+    if object_type is DracoPy.DracoMesh:
+        assert type(decoded_object) is DracoPy.DracoMesh
+    else:
+        assert type(decoded_object) is DracoPy.DracoPointCloud
 
-    assert len(decoded_mesh.attributes) == len(
-        set([attr["unique_id"] for attr in decoded_mesh.attributes])
+    assert len(decoded_object.attributes) == len(
+        set([attr["unique_id"] for attr in decoded_object.attributes])
     )
-    decoded_tangents = decoded_mesh.get_attribute_by_unique_id(0)
-    decoded_joints = decoded_mesh.get_attribute_by_unique_id(1)
-    decoded_weights = decoded_mesh.get_attribute_by_unique_id(3)
+    decoded_tangents = decoded_object.get_attribute_by_unique_id(0)
+    decoded_joints = decoded_object.get_attribute_by_unique_id(1)
+    decoded_weights = decoded_object.get_attribute_by_unique_id(3)
 
     assert decoded_tangents["attribute_type"] == DracoPy.AttributeType.GENERIC
     assert decoded_tangents["data_type"] == DracoPy.DataType.DT_FLOAT32
@@ -312,7 +320,8 @@ def test_generic_attributes():
     assert np.allclose(decoded_weights["data"], test_weights)
 
 
-def test_named_generic_attributes():
+@pytest.mark.parametrize("object_type", [DracoPy.DracoMesh, DracoPy.DracoPointCloud])
+def test_named_generic_attributes(object_type):
     # Read reference mesh
     with open(os.path.join(testdata_directory, "bunny.drc"), 'rb') as draco_file:
         mesh = DracoPy.decode(draco_file.read())
@@ -328,17 +337,24 @@ def test_named_generic_attributes():
         'joints': test_joints,
         'weights': test_weights
     }
-    binary = DracoPy.encode(mesh.points, mesh.faces, generic_attributes=generic_attributes)
+    if object_type is DracoPy.DracoMesh:
+        binary = DracoPy.encode(mesh.points, mesh.faces, generic_attributes=generic_attributes)
+    else:
+        binary = DracoPy.encode(mesh.points, generic_attributes=generic_attributes)
 
     # Decode and verify attributes
-    decoded_mesh = DracoPy.decode(binary)
-
-    assert len(decoded_mesh.attributes) == len(
-        set([attr["unique_id"] for attr in decoded_mesh.attributes])
+    decoded_object = DracoPy.decode(binary)
+    if object_type is DracoPy.DracoMesh:
+        assert type(decoded_object) is DracoPy.DracoMesh
+    else:
+        assert type(decoded_object) is DracoPy.DracoPointCloud
+    
+    assert len(decoded_object.attributes) == len(
+        set([attr["unique_id"] for attr in decoded_object.attributes])
     )
-    decoded_tangents = decoded_mesh.get_attribute_by_name('tangents')
-    decoded_joints = decoded_mesh.get_attribute_by_name('joints')
-    decoded_weights = decoded_mesh.get_attribute_by_name('weights')
+    decoded_tangents = decoded_object.get_attribute_by_name('tangents')
+    decoded_joints = decoded_object.get_attribute_by_name('joints')
+    decoded_weights = decoded_object.get_attribute_by_name('weights')
 
     assert decoded_tangents["attribute_type"] == DracoPy.AttributeType.GENERIC
     assert decoded_tangents["data_type"] == DracoPy.DataType.DT_FLOAT32


### PR DESCRIPTION
Building upon #59 and #60, this PR contains two commits:

- [Ensure attribute unique_ids are always unique](https://github.com/seung-lab/DracoPy/commit/0cfc95a37193ce1b94b6d1e18ede68c634ffe947)
  - Fixes an issue where `unique_id`s can be duplicated between native attributes (i.e., of type `POSITION`, `NORMAL`, `COLOR`, `TEX_COORD`) and `GENERIC` attributes, which may interfere with `DracoPointCloud.get_attribute_by_unique_id`.
- [Enable generic attributes for point clouds in addition to meshes](https://github.com/seung-lab/DracoPy/commit/29bb2cefad79c3b1be5b833c2c3b4fae29c8aad7)
  - Plumbs through encoding/decoding of generic attributes for point clouds (#59 and #60 only implement this for meshes).

Thanks for creating this wrapper library!